### PR TITLE
Added a option to have Z1.0 as 7th column in the .stl files.

### DIFF
--- a/bbp/comps/station.py
+++ b/bbp/comps/station.py
@@ -48,6 +48,7 @@ class Station(object):
     vs30 = None
     low_freq_corner = 1.0e-15
     high_freq_corner = 1.0e+15
+    Z1pt0 = None
 
     # SDSU fields
     x = None
@@ -56,7 +57,7 @@ class Station(object):
     vs = None
     rho = None
     kappa = None
-
+    
 if __name__ == "__main__":
     print("Testing Module: %s" % (sys.argv[0]))
     ME = Station()

--- a/bbp/comps/station_list.py
+++ b/bbp/comps/station_list.py
@@ -104,6 +104,12 @@ class StationList(object):
                         station.high_freq_corner = 1.0e+15
                     else:
                         station.high_freq_corner = float(sta[5])
+                # Handle the optional Z1.0 information.
+                try:
+                    station.Z1pt0 = float(sta[6]) if len(sta)>=7 else None 
+                except ValueError:
+                    station.Z1pt0 = None
+ 
                 self.site_list.append(station)
         # Remember to close the file
         try:


### PR DESCRIPTION
In this pull request, I introduce support for 7th column to be read as Z1.0 in the station list (.stl) file. 

Changes include:

1. Added Z1.0 attribute to the _station_ class in **station.py** file. 
2. Added a few lines in the _StationList_ class in **station_list.py** file to assign 7th column values in .stl file to Z1.0 values if present. 