### PR TITLE
Fix SDSU ray tracer buffer overflow and modernize Python tests

### DIFF
--- a/bbp/src/sdsu/bbtoolbox/ray3DJHfor.c
+++ b/bbp/src/sdsu/bbtoolbox/ray3DJHfor.c
@@ -89,6 +89,8 @@ if I don't answer the e-mail (our computers are in a state of flux).   */
 #include    <math.h>
 #include    <fcntl.h>
 #include    <string.h>
+#include    <stdlib.h>
+#include    <unistd.h>
 
 #define PI 3.141592654
 #define SQR2 1.414213562
@@ -202,8 +204,8 @@ void raytracing_(hypo,grid,step,PS_flag)
 		/*timefile[80],	 file in which travel times appear at the end */
                 wallfile[80];   /* file containing input wall values of traveltimes */
 
-        char  *velfile=malloc(11);
-        char  *timefile=malloc(12);
+        char  *velfile=malloc(80);
+        char  *timefile=malloc(80);
         FILE  *vfint, *tfint;
 
 	/* ARRAY TO ORDER SIDE FOR SOLUTION IN THE RIGHT ORDER */
@@ -1701,7 +1703,7 @@ void raytracing_(hypo,grid,step,PS_flag)
 
 /* -------------------------------------------------------------------------- */
 
-compar(a,b)
+int compar(a,b)
 struct sorted *a, *b;
 {
 	if(a->time > b->time) return(1);

--- a/bbp/tests/test_python_code.py
+++ b/bbp/tests/test_python_code.py
@@ -52,29 +52,29 @@ class TestPythonCode(unittest.TestCase):
         Run Broadband Plotform to make sure we can start it
         """
         self.install = InstallCfg()
-        cmd = ("python3 %s -v >/dev/null" %
-               (os.path.join(self.install.A_COMP_DIR,
-                             "run_bbp.py")))
+        cmd = ("%s %s -v >/dev/null" %
+               (sys.executable, os.path.join(self.install.A_COMP_DIR,
+                                             "run_bbp.py")))
         self.assertFalse(bband_utils.runprog(cmd, False) != 0,
                          "Cannot start Broadband plotform!")
 
     def test_python_code_comps(self):
         """
-        Run Python with -tt flag to detect mix of tabs and spaces in the code
+        Run Python compileall to detect mix of tabs and spaces in the code
         """
         self.install = InstallCfg()
-        cmd = ("python3 -tt -m compileall -f -q -l %s" %
-               (self.install.A_COMP_DIR))
+        cmd = ("%s -m compileall -f -q -l %s" %
+               (sys.executable, self.install.A_COMP_DIR))
         self.assertFalse(bband_utils.runprog(cmd, False) != 0,
                          "Python code in comps directory mixes tabs and spaces!")
 
     def test_python_code_tests(self):
         """
-        Run Python with -tt flag to detect mix of tabs and spaces in the code
+        Run Python compileall to detect mix of tabs and spaces in the code
         """
         self.install = InstallCfg()
-        cmd = ("python -tt -m compileall -f -q -l %s" %
-               (self.install.A_TEST_DIR))
+        cmd = ("%s -m compileall -f -q -l %s" %
+               (sys.executable, self.install.A_TEST_DIR))
         self.assertFalse(bband_utils.runprog(cmd, False) != 0,
                          "Python code in test directory mixes tabs and spaces!")
 


### PR DESCRIPTION
This PR addresses two compatibility issues when running the BBP on modern operating systems with stricter compilers (e.g., GCC 11, Ubuntu 22.04+).

### 1. SDSU Ray Tracer Segmentation Fault (`ray3DJHfor.c`)
* **Issue:** The SDSU `BBtoolbox.exe` binary was crashing with a segmentation fault during the high-frequency scattering generation. Modern GCC compilers flag a string buffer overflow.
* **Fix:** The `malloc` allocations for `timefile` and `velfile` on lines 205-206 were originally sized at exactly 12 and 11 bytes, which did not account for the hidden `\0` null terminator required by `strcpy`. This caused memory corruption on strict compilers. Increased the allocation size to 80 bytes and included `<stdlib.h>` and `<unistd.h>` to resolve implicit declaration errors. 

### 2. Python Environment Test Failure (`test_python_code.py`)
* **Issue:** The `test_python_code_tests` unit test was failing with a `python: not found` error and throwing unknown option errors for `-tt`. Modern Linux environments often alias to `python3` exclusively, and Python 3 natively rejects mixed tabs and spaces, rendering the `-tt` flag obsolete.
* **Fix:** Updated the shell commands in `test_execute_platform_bbp`, `test_python_code_comps`, and `test_python_code_tests` to use `sys.executable` instead of hardcoded `python` or `python3` strings, ensuring the tests always use the active Python environment. Removed the deprecated `-tt` flags.